### PR TITLE
Add package start script and usage docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+logs/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # timtrack
+
+To run the project:
+
+```
+npm install
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "timtrack",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
## Summary
- add npm start script in `package.json`
- ignore node modules and log files
- update README with npm install/start instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6874311e998c83248afa82ea743b80c2