### PR TITLE
Implement static server & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# timtrack
+# Timtrack
+
+Simple static file server.
+
+Run the server:
+
+```
+npm start
+```
+
+Run tests:
+
+```
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "timtrack",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  }
+}

--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>About</title>
+</head>
+<body>
+  <h1>About Timtrack</h1>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Home</title>
+</head>
+<body>
+  <h1>Welcome to Timtrack</h1>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,38 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+
+function serveFile(res, filePath) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath).slice(1);
+    const type = {
+      html: 'text/html',
+      css: 'text/css',
+      js: 'text/javascript',
+      json: 'application/json'
+    }[ext] || 'text/plain';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const file = url.pathname === '/' ? 'index.html' : url.pathname.replace(/^\/+/, '');
+  serveFile(res, path.join(__dirname, 'public', file));
+});
+
+if (require.main === module) {
+  server.listen(port, () => {
+    console.log(`Server running at http://localhost:${port}/`);
+  });
+}
+
+module.exports = server;

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,45 @@
+const { test, before, after } = require('node:test');
+const assert = require('assert');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const server = require('./server');
+
+const port = 8123;
+
+function request(pathname) {
+  return new Promise((resolve, reject) => {
+    http.get({ port, path: pathname }, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ statusCode: res.statusCode, data }));
+    }).on('error', reject);
+  });
+}
+
+before(async () => {
+  await new Promise(res => server.listen(port, res));
+});
+
+after(async () => {
+  await new Promise(res => server.close(res));
+});
+
+test('serves index page', async () => {
+  const res = await request('/');
+  const expected = fs.readFileSync(path.join(__dirname, 'public', 'index.html'), 'utf8');
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.data, expected);
+});
+
+test('serves about page', async () => {
+  const res = await request('/about.html');
+  const expected = fs.readFileSync(path.join(__dirname, 'public', 'about.html'), 'utf8');
+  assert.strictEqual(res.statusCode, 200);
+  assert.strictEqual(res.data, expected);
+});
+
+test('returns 404 for missing page', async () => {
+  const res = await request('/missing.html');
+  assert.strictEqual(res.statusCode, 404);
+});


### PR DESCRIPTION
## Summary
- add a simple Node HTTP server
- serve static files from `/public`
- include example `index.html` and `about.html`
- provide package scripts and documentation
- verify file serving via Node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874311d44748324887c9807dc9463ca